### PR TITLE
Add yarn support, add support for private git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apk add --no-cache \
     nodejs-npm \
     openssh-client \
     postgresql-libs \
-    rsync
+    rsync \
+    yarn
 
 # Install php extensions
 RUN pecl install imagick

--- a/gitlab/.gitlab-ci.deployments.yml
+++ b/gitlab/.gitlab-ci.deployments.yml
@@ -33,15 +33,15 @@ composer:
       - vendor/
       - .env
 
-npm:
+node:
   stage: build
   cache:
-    key: ${CI_COMMIT_REF_SLUG}-npm
+    key: ${CI_COMMIT_REF_SLUG}-node
     paths:
       - node_modules/
   script:
-      - npm install
-      - npm run production
+      - ${NODE_MODULE_MANAGER:-npm} install
+      - ${NODE_MODULE_MANAGER:-npm} run production
   artifacts:
     expire_in: 1 month
     paths:

--- a/gitlab/.gitlab-ci.deployments.yml
+++ b/gitlab/.gitlab-ci.deployments.yml
@@ -2,7 +2,8 @@ image: lorisleiva/laravel-docker:latest
 
 .init_ssh: &init_ssh |
   eval $(ssh-agent -s)
-  echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
+  echo "$SSH_PRIVATE_KEY_DEPLOYMENTS" | tr -d '\r' | ssh-add - > /dev/null
+  echo "$SSH_PRIVATE_KEY_DEPENDENCIES" | tr -d '\r' | ssh-add - > /dev/null
   mkdir -p ~/.ssh
   chmod 700 ~/.ssh
   [[ -f /.dockerenv ]] && echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
@@ -24,6 +25,7 @@ composer:
     paths:
       - vendor/
   script:
+      - *init_ssh
       - composer install --prefer-dist --no-ansi --no-interaction --no-progress --no-scripts
       - cp .env.example .env
       - php artisan key:generate
@@ -40,6 +42,7 @@ node:
     paths:
       - node_modules/
   script:
+      - *init_ssh
       - ${NODE_MODULE_MANAGER:-npm} install
       - ${NODE_MODULE_MANAGER:-npm} run production
   artifacts:


### PR DESCRIPTION
Hi !

1- Would you consider adding yarn as an effective replacement for npm. It runs faster and in the long run it can speed up CI and save some minutes :-) I added a variable to allow end-users to select between npm and yarn => just set NODE_MODULE_MANAGER = yarn

2- I added some ssh management to be able to retrieve composer and npm packages from private repositories.

Thanks for your great, fully reusable work !