### PR TITLE
Add JPEG support to gd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache \
     imagemagick \
     libc-dev \
     libpng-dev \
+    libzip-dev \
     freetype \
     libpng \
     libjpeg-turbo \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,13 @@ RUN apk add --no-cache \
     rsync
 
 # Install php extensions
-RUN pecl install imagick
+RUN pecl install \
+    imagick \
+    xdebug
 RUN pear install PHP_CodeSniffer
-RUN docker-php-ext-enable imagick
+RUN docker-php-ext-enable \
+    imagick \
+    xdebug
 RUN docker-php-ext-install \
     curl \
     iconv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ RUN apk add --no-cache \
     imagemagick \
     libc-dev \
     libpng-dev \
+    freetype \
+    libpng \
+    libjpeg-turbo \
+    freetype-dev \
+    libjpeg-turbo-dev \
     make \
     mysql-client \
     nodejs \
@@ -43,8 +48,12 @@ RUN docker-php-ext-install \
     pcntl \
     tokenizer \
     xml \
-    gd \
     zip
+RUN docker-php-ext-configure gd \
+    --with-freetype-dir=/usr/include/ \
+    --with-png-dir=/usr/include/ \
+    --with-jpeg-dir=/usr/include/
+RUN NPROC=$(getconf _NPROCESSORS_ONLN)&& docker-php-ext-install -j${NPROC} gd
 
 # Install composer
 RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apk add --no-cache \
 # Install php extensions
 RUN pecl install \
     imagick
-RUN pear install PHP_CodeSniffer
+# RUN pear install PHP_CodeSniffer
 RUN docker-php-ext-enable \
     imagick
 RUN docker-php-ext-install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN pear install PHP_CodeSniffer
 RUN docker-php-ext-enable \
     imagick
 RUN docker-php-ext-install \
+    exif \
     curl \
     iconv \
     mbstring \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN pear install PHP_CodeSniffer
 RUN docker-php-ext-enable \
     imagick
 RUN docker-php-ext-install \
+    bcmath \
     exif \
     curl \
     iconv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apk add --no-cache \
     python \
     py-pip \
     groff \
+    wkhtmltopdf \
     zip \
     zlib-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:alpine
+FROM php:7.2-alpine
 
 # Install dev dependencies
 RUN apk add --no-cache --virtual .build-deps \
@@ -75,6 +75,9 @@ ENV PATH="./vendor/bin:$PATH"
 
 # Install AWS CLI
 RUN pip install awscli
+
+# Install PHP_CodeSniffer
+RUN composer global require "squizlabs/php_codesniffer=*"
 
 # Cleanup dev dependencies
 RUN apk del -f .build-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache --virtual .build-deps \
     imagemagick-dev \
     libtool \
     libxml2-dev \
+    php7-phpdbg \
     postgresql-dev \
     sqlite-dev
 
@@ -41,12 +42,10 @@ RUN apk add --no-cache \
 
 # Install php extensions
 RUN pecl install \
-    imagick \
-    xdebug
+    imagick
 # RUN pear install PHP_CodeSniffer
 RUN docker-php-ext-enable \
-    imagick \
-    xdebug
+    imagick
 RUN docker-php-ext-configure zip --with-libzip
 RUN docker-php-ext-install \
     bcmath \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,10 @@ RUN apk add --no-cache \
 
 # Install php extensions
 RUN pecl install \
-    imagick \
-    xdebug
+    imagick
 RUN pear install PHP_CodeSniffer
 RUN docker-php-ext-enable \
-    imagick \
-    xdebug
+    imagick
 RUN docker-php-ext-install \
     curl \
     iconv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,18 @@ RUN apk add --no-cache \
     python \
     py-pip \
     groff \
-    zip
+    zip \
+    zlib-dev
 
 # Install php extensions
 RUN pecl install \
-    imagick
+    imagick \
+    xdebug
 # RUN pear install PHP_CodeSniffer
 RUN docker-php-ext-enable \
-    imagick
+    imagick \
+    xdebug
+RUN docker-php-ext-configure zip --with-libzip
 RUN docker-php-ext-install \
     bcmath \
     exif \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN apk add --no-cache \
     rsync \
     python \
     py-pip \
-    groff
+    groff \
+    zip
 
 # Install php extensions
 RUN pecl install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ RUN apk add --no-cache \
     openssh-client \
     postgresql-libs \
     rsync \
-    aws-cli
+    python \
+    py-pip \
+    groff
 
 # Install php extensions
 RUN pecl install \
@@ -64,6 +66,9 @@ RUN NPROC=$(getconf _NPROCESSORS_ONLN)&& docker-php-ext-install -j${NPROC} gd
 RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV PATH="./vendor/bin:$PATH"
+
+# Install AWS CLI
+RUN pip install awscli
 
 # Cleanup dev dependencies
 RUN apk del -f .build-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN apk add --no-cache \
     nodejs-npm \
     openssh-client \
     postgresql-libs \
-    rsync
+    rsync \
+    aws-cli
 
 # Install php extensions
 RUN pecl install \


### PR DESCRIPTION
We have some unit tests that rely on `imagejpeg()` being available but the current php-gd extension doesn't have JPEG support. This adds the necessary libraries to install gd with JPEG support.