### PR TITLE
Adding Xdebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apk add --no-cache \
     rsync
 
 # Install php extensions
-RUN pecl install imagick
+RUN pecl install imagick \
+    pecl install xdebug && docker-php-ext-enable xdebug
 RUN pear install PHP_CodeSniffer
 RUN docker-php-ext-enable imagick
 RUN docker-php-ext-install \


### PR DESCRIPTION
The blog post on; http://lorisleiva.com/using-gitlabs-pipeline-with-laravel/, uses the flag `--coverage-text`, for `phpunit`, indicating that code coverage will be reported, however the current image does not have the needed pecl extensions installed. This pull request adds support for code coverage. Issue #6 