### PR TITLE
Alternative install method for PHP_CodeSniffer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,18 +26,20 @@ RUN apk add --no-cache \
     nodejs-npm \
     openssh-client \
     postgresql-libs \
-    rsync
+    rsync \
+    zlib-dev \
+    libzip-dev
 
 # Install PECL and PEAR extensions
 RUN pecl install \
     imagick \
     xdebug
-RUN pear install PHP_CodeSniffer
 
 # Install and enable php extensions
 RUN docker-php-ext-enable \
     imagick \
     xdebug
+RUN docker-php-ext-configure zip --with-libzip
 RUN docker-php-ext-install \
     curl \
     iconv \
@@ -52,6 +54,9 @@ RUN docker-php-ext-install \
     gd \
     zip \
     bcmath
+
+# Install PHP_CodeSniffer
+RUN composer global require "squizlabs/php_codesniffer=*"
 
 # Install composer
 RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer


### PR DESCRIPTION
Hello!
I maintain a [fork of this image that adds yarn](https://github.com/fgilio/laravel-docker). 
Yesterday I noticed the image builds where failing and the problem was installing PHP_CodeSniffer, so I made this changes to install it using Composer instead of PEAR.
I guess this might be related to [the site being down](https://user-images.githubusercontent.com/6857732/52348772-e5ca0000-2a03-11e9-891f-39c69e971545.png) 
http://pear.php.net/

Here's a screenshot of the error I was getting:
![screen shot 2019-02-06 at 11 34 09](https://user-images.githubusercontent.com/6857732/52348699-b74c2500-2a03-11e9-93d9-6c878e1b93f6.png)

**EDIT**: `libzip` is required or [the build fails](https://user-images.githubusercontent.com/6857732/52348947-3a6d7b00-2a04-11e9-93dc-31c2a0c3c620.png) while installing PHP_CodeSniffer