### PR TITLE
Add support for using `yarn`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --no-cache \
     mysql-client \
     nodejs \
     nodejs-npm \
+    yarn \
     openssh-client \
     postgresql-libs \
     rsync \


### PR DESCRIPTION
In [publica.la](https://publica.la) we've been using [my fork](https://github.com/fgilio/laravel-docker/commit/a65e1fb6b12261c0112ed7839aa342a1e33059cd) with `yarn` support for some months, it works perfectly. I'd love to stop using it and use this instead 🚀 