### PR TITLE
Fix iconv issue with alpine image

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -68,5 +68,9 @@ RUN composer global require "squizlabs/php_codesniffer=*"
 # Cleanup dev dependencies
 RUN apk del -f .build-deps
 
+# fix work iconv library with alphine
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted gnu-libiconv
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
 # Setup working directory
 WORKDIR /var/www

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -68,5 +68,9 @@ RUN composer global require "squizlabs/php_codesniffer=*"
 # Cleanup dev dependencies
 RUN apk del -f .build-deps
 
+# fix work iconv library with alphine
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted gnu-libiconv
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
 # Setup working directory
 WORKDIR /var/www

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -66,5 +66,9 @@ RUN composer global require "squizlabs/php_codesniffer=*"
 # Cleanup dev dependencies
 RUN apk del -f .build-deps
 
+# fix work iconv library with alphine
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted gnu-libiconv
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
 # Setup working directory
 WORKDIR /var/www

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -66,5 +66,9 @@ RUN composer global require "squizlabs/php_codesniffer=*"
 # Cleanup dev dependencies
 RUN apk del -f .build-deps
 
+# fix work iconv library with alphine
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ --allow-untrusted gnu-libiconv
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
 # Setup working directory
 WORKDIR /var/www


### PR DESCRIPTION
When usign Nuno Maduros [insights package for Laravel](https://github.com/nunomaduro/phpinsights), the required Nette package does not handle the iconv function properly as discussed here: https://github.com/nunomaduro/phpinsights/issues/43 

I tried the solution and created the topredmedia/laravel-docker image on docker hub. The problem is fixed with this PR.