### PR TITLE
Add exif extension

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -43,6 +43,7 @@ RUN docker-php-ext-enable \
 RUN docker-php-ext-configure zip --with-libzip
 RUN docker-php-ext-install \
     curl \
+    exif \
     iconv \
     mbstring \
     pdo \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -43,6 +43,7 @@ RUN docker-php-ext-enable \
 RUN docker-php-ext-configure zip --with-libzip
 RUN docker-php-ext-install \
     curl \
+    exif \
     iconv \
     mbstring \
     pdo \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -43,6 +43,7 @@ RUN docker-php-ext-enable \
 RUN docker-php-ext-configure zip --with-libzip
 RUN docker-php-ext-install \
     curl \
+    exif \
     iconv \
     mbstring \
     pdo \


### PR DESCRIPTION
👋 Hello!
This extension is present by default in Forge provided servers, I think it would be expected to have it here too. Just bumped into this while trying to deploy a project that uses [https://github.com/spatie/image](https://github.com/spatie/image/blob/master/composer.json)

What do you think?