### PR TITLE
mysqldump not found, rather mariadb

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache \
     libpng-dev \
     libzip-dev \
     make \
-    mysql-client \
+    mariadb-client \
     nodejs \
     nodejs-npm \
     yarn \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache \
     libpng-dev \
     libzip-dev \
     make \
-    mysql-client \
+    mariadb-client \
     nodejs \
     nodejs-npm \
     oniguruma-dev \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache \
     libpng-dev \
     libzip-dev \
     make \
-    mysql-client \
+    mariadb-client \
     nodejs \
     nodejs-npm \
     oniguruma-dev \


### PR DESCRIPTION
mysql name changed to mariadb.

`Command not found : sh: 1: /mysqldump: not found`