### PR TITLE
Install imagick for php8.0

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -28,7 +28,7 @@ RUN apk add --no-cache \
     make \
     mysql-client \
     nodejs \
-    nodejs-npm \
+    npm \
     oniguruma-dev \
     yarn \
     openssh-client \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -39,13 +39,13 @@ RUN apk add --no-cache \
 # Install PECL and PEAR extensions
 RUN pecl install \
     redis \
-    # imagick \
+    imagick \
     xdebug
 
 # Enable PECL and PEAR extensions
 RUN docker-php-ext-enable \
     redis \
-    # imagick \
+    imagick \
     xdebug
 
 # Configure php extensions

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | - | - | - |
 | 7.3 | 7.3 | ✅ Everything. |
 | 7.4 | 7.4 | ✅ Everything. |
-| 8.0 | 8.0 | 🚧 [Extension `imagick` missing](https://github.com/Imagick/imagick/issues/358). |
+| 8.0 | 8.0 | ✅ Everything. |
 | stable | **7.4** | 🔗 Aliases the latest stable version of PHP that supports all features of this docker image.  |
 | latest | **8.0** | 🔗 Aliases the latest stable version of PHP available (even if that version does not support all features yet). |
 


### PR DESCRIPTION
Due to the base image tag using 8.0-alpine, i also had to change the `nodejs-npm` package to `npm`

see: https://pkgs.alpinelinux.org/packages?name=npm&branch=v3.8