### PR TITLE
Add packages workflow to build and push images

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -25,8 +25,6 @@ jobs:
             php: '8.0'
           - tag: '7.4'
             php: '7.4'
-          - tag: '7.3'
-            php: '7.3'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds a workflow for GitHub Actions to build and push the images to the GitHub container Registry and Docker Hub.

Please review and merge the PR #79 first. This PR already includes the new image.

You have to set up the secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` that the action can log in to your Docker Hub account.

Currently, only the tags `7.3`, `7.4`, `8.0` and `8.1` will be pushed. 