### PR TITLE
update dependabot config + pin version of base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/7.4"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/8.0"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/8.1"
     schedule:
       interval: "daily"
 

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-alpine3.13
+FROM php:7.4.24-alpine3.13
 
 # Install dev dependencies
 RUN apk add --no-cache --virtual .build-deps \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-alpine3.13
+FROM php:8.0.11-alpine3.13
 
 # Install dev dependencies
 RUN apk add --no-cache --virtual .build-deps \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-rc-alpine3.13
+FROM php:8.1.0RC4-alpine3.13
 
 # Install dev dependencies
 RUN apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
A follow PR for #81. Should solve the dependabot issue. Additional we should pin the version of the base images. Dependabot will update the version via PRs.