### PR TITLE
bump php 8.1 image to the latest version

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.0RC6-alpine3.13
+FROM php:8.1-alpine3.15
 
 # Install dev dependencies
 RUN apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
It seems that's Dependabot bot isn't update PHP 8.1 to the latest version. This PR updates the base image of PHP 8.1 to the latest image.