### PR TITLE
Install php extension with `docker-php-extension-installer` + get rid of already installed extension

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,58 +1,17 @@
 FROM php:7.4.26-alpine3.13
 
+# Add docker-php-extension-installer script
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
 # Install dev dependencies
-RUN apk add --no-cache --virtual .build-deps \
-    $PHPIZE_DEPS \
-    curl-dev \
-    imagemagick-dev \
-    libtool \
-    libxml2-dev \
-    postgresql-dev \
-    sqlite-dev
-
-# Install production dependencies
-RUN apk add --no-cache \
-    bash \
-    curl \
-    freetype-dev \
-    g++ \
-    gcc \
-    git \
-    icu-dev \
-    icu-libs \
-    imagemagick \
-    libc-dev \
-    libjpeg-turbo-dev \
-    libpng-dev \
-    libzip-dev \
-    make \
-    mysql-client \
-    nodejs \
-    npm \
-    oniguruma-dev \
-    yarn \
-    openssh-client \
-    postgresql-libs \
-    rsync \
-    zlib-dev
-
-# Install PECL and PEAR extensions
-RUN pecl install \
-    redis \
-    imagick \
-    xdebug
-
-# Enable PECL and PEAR extensions
-RUN docker-php-ext-enable \
-    redis \
-    imagick \
-    xdebug
-
-# Configure php extensions
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN apk add --no-cache --virtual .build-deps
 
 # Install php extensions
-RUN docker-php-ext-install \
+RUN chmod +x /usr/local/bin/install-php-extensions && \
+    install-php-extensions \
+    redis \
+    imagick \
+    xdebug \
     bcmath \
     calendar \
     curl \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -14,20 +14,13 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
     xdebug \
     bcmath \
     calendar \
-    curl \
     exif \
     gd \
-    iconv \
     intl \
-    mbstring \
-    pdo \
     pdo_mysql \
     pdo_pgsql \
-    pdo_sqlite \
     pcntl \
     soap \
-    tokenizer \
-    xml \
     zip
 
 # Install composer

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -9,9 +9,9 @@ RUN apk add --no-cache --virtual .build-deps
 # Install php extensions
 RUN chmod +x /usr/local/bin/install-php-extensions && \
     install-php-extensions \
-    redis \
-    imagick \
-    xdebug \
+    redis-stable \
+    imagick-stable \
+    xdebug-stable \
     bcmath \
     calendar \
     exif \

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -3,12 +3,21 @@ FROM php:7.4.26-alpine3.13
 # Add docker-php-extension-installer script
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-# Install dev dependencies
-RUN apk add --no-cache --virtual .build-deps
+# Install dependencies
+RUN apk add --no-cache \
+    bash \
+    curl \
+    mysql-client \
+    nodejs \
+    npm \
+    yarn \
+    openssh-client \
+    rsync
 
 # Install php extensions
 RUN chmod +x /usr/local/bin/install-php-extensions && \
     install-php-extensions \
+    @composer \
     redis-stable \
     imagick-stable \
     xdebug-stable \
@@ -23,17 +32,8 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
     soap \
     zip
 
-# Install composer
-ENV COMPOSER_HOME /composer
-ENV PATH ./vendor/bin:/composer/vendor/bin:$PATH
-ENV COMPOSER_ALLOW_SUPERUSER 1
-RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
-
 # Install PHP_CodeSniffer
 RUN composer global require "squizlabs/php_codesniffer=*"
-
-# Cleanup dev dependencies
-RUN apk del -f .build-deps
 
 # Setup working directory
 WORKDIR /var/www

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,58 +1,17 @@
 FROM php:8.0.13-alpine3.13
 
+# Add docker-php-extension-installer script
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
 # Install dev dependencies
-RUN apk add --no-cache --virtual .build-deps \
-    $PHPIZE_DEPS \
-    curl-dev \
-    imagemagick-dev \
-    libtool \
-    libxml2-dev \
-    postgresql-dev \
-    sqlite-dev
-
-# Install production dependencies
-RUN apk add --no-cache \
-    bash \
-    curl \
-    freetype-dev \
-    g++ \
-    gcc \
-    git \
-    icu-dev \
-    icu-libs \
-    imagemagick \
-    libc-dev \
-    libjpeg-turbo-dev \
-    libpng-dev \
-    libzip-dev \
-    make \
-    mysql-client \
-    nodejs \
-    npm \
-    oniguruma-dev \
-    yarn \
-    openssh-client \
-    postgresql-libs \
-    rsync \
-    zlib-dev
-
-# Install PECL and PEAR extensions
-RUN pecl install \
-    redis \
-    imagick \
-    xdebug
-
-# Enable PECL and PEAR extensions
-RUN docker-php-ext-enable \
-    redis \
-    imagick \
-    xdebug
-
-# Configure php extensions
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN apk add --no-cache --virtual .build-deps
 
 # Install php extensions
-RUN docker-php-ext-install \
+RUN chmod +x /usr/local/bin/install-php-extensions && \
+    install-php-extensions \
+    redis \
+    imagick \
+    xdebug \
     bcmath \
     calendar \
     curl \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -3,12 +3,21 @@ FROM php:8.0.13-alpine3.13
 # Add docker-php-extension-installer script
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-# Install dev dependencies
-RUN apk add --no-cache --virtual .build-deps
+# Install dependencies
+RUN apk add --no-cache \
+    bash \
+    curl \
+    mysql-client \
+    nodejs \
+    npm \
+    yarn \
+    openssh-client \
+    rsync
 
 # Install php extensions
 RUN chmod +x /usr/local/bin/install-php-extensions && \
     install-php-extensions \
+    @composer \
     redis-stable \
     imagick-stable \
     xdebug-stable \
@@ -23,17 +32,8 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
     soap \
     zip
 
-# Install composer
-ENV COMPOSER_HOME /composer
-ENV PATH ./vendor/bin:/composer/vendor/bin:$PATH
-ENV COMPOSER_ALLOW_SUPERUSER 1
-RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
-
 # Install PHP_CodeSniffer
 RUN composer global require "squizlabs/php_codesniffer=*"
-
-# Cleanup dev dependencies
-RUN apk del -f .build-deps
 
 # Setup working directory
 WORKDIR /var/www

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -14,20 +14,13 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
     xdebug \
     bcmath \
     calendar \
-    curl \
     exif \
     gd \
-    iconv \
     intl \
-    mbstring \
-    pdo \
     pdo_mysql \
     pdo_pgsql \
-    pdo_sqlite \
     pcntl \
     soap \
-    tokenizer \
-    xml \
     zip
 
 # Install composer

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -9,9 +9,9 @@ RUN apk add --no-cache --virtual .build-deps
 # Install php extensions
 RUN chmod +x /usr/local/bin/install-php-extensions && \
     install-php-extensions \
-    redis \
-    imagick \
-    xdebug \
+    redis-stable \
+    imagick-stable \
+    xdebug-stable \
     bcmath \
     calendar \
     exif \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -3,12 +3,21 @@ FROM php:8.1.0RC6-alpine3.13
 # Add docker-php-extension-installer script
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-# Install dev dependencies
-RUN apk add --no-cache --virtual .build-deps
+# Install dependencies
+RUN apk add --no-cache \
+    bash \
+    curl \
+    mysql-client \
+    nodejs \
+    npm \
+    yarn \
+    openssh-client \
+    rsync
 
 # Install php extensions
 RUN chmod +x /usr/local/bin/install-php-extensions && \
     install-php-extensions \
+    @composer \
     redis-stable \
     imagick-stable \
     xdebug-stable \
@@ -23,17 +32,8 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
     soap \
     zip
 
-# Install composer
-ENV COMPOSER_HOME /composer
-ENV PATH ./vendor/bin:/composer/vendor/bin:$PATH
-ENV COMPOSER_ALLOW_SUPERUSER 1
-RUN curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
-
 # Install PHP_CodeSniffer
 RUN composer global require "squizlabs/php_codesniffer=*"
-
-# Cleanup dev dependencies
-RUN apk del -f .build-deps
 
 # Setup working directory
 WORKDIR /var/www

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -9,9 +9,9 @@ RUN apk add --no-cache --virtual .build-deps
 # Install php extensions
 RUN chmod +x /usr/local/bin/install-php-extensions && \
     install-php-extensions \
-    redis \
-    imagick \
-    xdebug \
+    redis-stable \
+    imagick-stable \
+    xdebug-stable \
     bcmath \
     calendar \
     exif \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,58 +1,17 @@
 FROM php:8.1.0RC6-alpine3.13
 
+# Add docker-php-extension-installer script
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
 # Install dev dependencies
-RUN apk add --no-cache --virtual .build-deps \
-    $PHPIZE_DEPS \
-    curl-dev \
-    imagemagick-dev \
-    libtool \
-    libxml2-dev \
-    postgresql-dev \
-    sqlite-dev
-
-# Install production dependencies
-RUN apk add --no-cache \
-    bash \
-    curl \
-    freetype-dev \
-    g++ \
-    gcc \
-    git \
-    icu-dev \
-    icu-libs \
-    imagemagick \
-    libc-dev \
-    libjpeg-turbo-dev \
-    libpng-dev \
-    libzip-dev \
-    make \
-    mysql-client \
-    nodejs \
-    npm \
-    oniguruma-dev \
-    yarn \
-    openssh-client \
-    postgresql-libs \
-    rsync \
-    zlib-dev
-
-# Install PECL and PEAR extensions
-RUN pecl install \
-    redis \
-    imagick \
-    xdebug
-
-# Enable PECL and PEAR extensions
-RUN docker-php-ext-enable \
-    redis \
-    imagick \
-    xdebug
-
-# Configure php extensions
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN apk add --no-cache --virtual .build-deps
 
 # Install php extensions
-RUN docker-php-ext-install \
+RUN chmod +x /usr/local/bin/install-php-extensions && \
+    install-php-extensions \
+    redis \
+    imagick \
+    xdebug \
     bcmath \
     calendar \
     exif \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -17,12 +17,10 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
     exif \
     gd \
     intl \
-    pdo \
     pdo_mysql \
     pdo_pgsql \
     pcntl \
     soap \
-    xml \
     zip
 
 # Install composer


### PR DESCRIPTION
This PR installs all required dependencies with the [`docker-php-extension-installer`](https://github.com/mlocati/docker-php-extension-installer/).

The `docker-php-extension-installer` shown that some extensions already installed. Therefore, I cleaned up the already installed extensions.

Closes #94 