### PR TITLE
Install `git` again after erroneously removing it

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -7,6 +7,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN apk add --no-cache \
     bash \
     curl \
+    git \
     mysql-client \
     nodejs \
     npm \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -7,6 +7,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN apk add --no-cache \
     bash \
     curl \
+    git \
     mysql-client \
     nodejs \
     npm \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -7,6 +7,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN apk add --no-cache \
     bash \
     curl \
+    git \
     mysql-client \
     nodejs \
     npm \


### PR DESCRIPTION
#95 accidentally removed `git` from the installed dependencies which causes the `git` command to no longer exist inside the container. This PR ensures that `git` gets installed again.

I didn't notice this while testing as our pipeline doesn't depend on the `git` command 😞 

Should close #96 