### PR TITLE
Bump alpine from 7.4.26-alpine3.13 to 7.4.26-alpine3.15 in /7.4

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.26-alpine3.13
+FROM php:7.4.26-alpine3.15
 
 # Add docker-php-extension-installer script
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/


### PR DESCRIPTION
I ran into problems regarding the old node.js / npm version in alpine 3.13 which is present in the 7.4 docker image. This updates alpine to the latest 3.15 version. I don't know if this could have bad side effects for other users because this updates a lot of packages.