### PR TITLE
Add GNU Autotools

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -5,6 +5,8 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 
 # Install dependencies
 RUN apk add --no-cache \
+    autoconf \
+    automake \
     bash \
     curl \
     freetype-dev \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -5,6 +5,8 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 
 # Install dependencies
 RUN apk add --no-cache \
+    autoconf \
+    automake \
     bash \
     curl \
     freetype-dev \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -5,6 +5,8 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 
 # Install dependencies
 RUN apk add --no-cache \
+    autoconf \
+    automake \
     bash \
     curl \
     freetype-dev \


### PR DESCRIPTION
I'm using imagemin in my build pipeline which depends on gifsicle. There seems to be no gifsicle binary available for Alpine Linux, so npm tries to build it from source, which fails because the GNU Autotools (automake, autoconf) are missing in the docker image.

```
> gifsicle@6.1.0 postinstall /var/www/oauth-server/node_modules/gifsicle
> node lib/install.js

spawn /var/www/oauth-server/node_modules/gifsicle/vendor/gifsicle ENOENT
gifsicle pre-build test failed
compiling from source
Error: Command failed: /bin/sh -c autoreconf -ivf
/bin/sh: autoreconf: not found
```

Adding them fixes this error. Do you think it is worth adding these packages generally?