### PR TITLE
fix php artisan postgres commands

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
     yarn \
     openssh-client \
     postgresql-libs \
+    postgresql-client \
     rsync \
     zlib-dev
 

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
     yarn \
     openssh-client \
     postgresql-libs \
+    postgresql-client \
     rsync \
     zlib-dev
 

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
     yarn \
     openssh-client \
     postgresql-libs \
+    postgresql-client \
     rsync \
     zlib-dev
 


### PR DESCRIPTION
Laravel uses pg_restore and pg_dump commands for the postgres database. Without this added the package the commands can't be run.