### PR TITLE
Install gcompat package

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
     freetype-dev \
     g++ \
     gcc \
+    gcompat \
     git \
     icu-dev \
     icu-libs \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
     freetype-dev \
     g++ \
     gcc \
+    gcompat \
     git \
     icu-dev \
     icu-libs \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
     freetype-dev \
     g++ \
     gcc \
+    gcompat \
     git \
     icu-dev \
     icu-libs \


### PR DESCRIPTION
so we can run glibc-based programs, which includes [bun](https://bun.sh). Without this, you run into [this error](https://github.com/oven-sh/bun/issues/5545).