### PR TITLE
Fix Release Pipeline PHP 8.3

### DIFF
--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -33,7 +33,7 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
     @composer \
     redis-stable \
     imagick-stable \
-    xdebug-stable \
+    xdebug-beta \
     bcmath \
     calendar \
     exif \


### PR DESCRIPTION
Hey @lorisleiva 

Sorry it looks like [XDebug](https://bugs.xdebug.org/roadmap_page.php?version_id=101) stable release will take some time. I set it to use the beta version for now.

I was not sure about Imagick, but it looks like it passed on the pipeline.

Thanks. 