### PR TITLE
Add postgresql-client in all versions

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
     oniguruma-dev \
     yarn \
     openssh-client \
+    postgresql-client\
     postgresql-libs \
     rsync \
     zlib-dev

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
     oniguruma-dev \
     yarn \
     openssh-client \
+    postgresql-client\
     postgresql-libs \
     rsync \
     zlib-dev

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -23,6 +23,7 @@ RUN apk add --no-cache \
     oniguruma-dev \
     yarn \
     openssh-client \
+    postgresql-client\
     postgresql-libs \
     rsync \
     zlib-dev


### PR DESCRIPTION
Hello,

we have seen that you add the PostgreSQL libraries but not the client which is necessary for Laravel to connect to PostgreSQL.

I leave it added to the 3 Dockerfiles.

Best regards